### PR TITLE
Allow generating empty arrays

### DIFF
--- a/jsf/parser.py
+++ b/jsf/parser.py
@@ -169,7 +169,15 @@ class JSF:
             }
         )
         root = arr if root is None else root
-        arr.items = self.__parse_definition(name, f"{path}/items", schema["items"], root=root)
+        if schema.get("items") is not None:
+            arr.items = self.__parse_definition(name, f"{path}/items", schema["items"], root=root)
+        else:
+            arr.items = self.__parse_definition(
+                name,
+                f"{path}/items",
+                {"type": list(Primitives.keys())},
+                root=root,
+            )
         return arr
 
     def __parse_tuple(
@@ -286,7 +294,11 @@ class JSF:
             elif item_type == "object" and "oneOf" in schema:
                 return self.__parse_oneOf(name, path, schema, root)
             elif item_type == "array":
-                if (schema.get("contains") is not None) or isinstance(schema.get("items"), dict):
+                if (
+                    (schema.get("contains") is not None)
+                    or isinstance(schema.get("items"), dict)
+                    or schema.get("items") is None
+                ):
                     return self.__parse_array(name, path, schema, root)
                 if isinstance(schema.get("items"), list) and all(
                     isinstance(x, dict) for x in schema.get("items", [])


### PR DESCRIPTION
## Summary
- Support array schemas without an `items` section by defaulting to generic primitive items
- Ensure parser treats arrays without `items` as arrays, enabling empty list generation

## Testing
- `pytest jsf/tests/test_gen_empty_list_temp.py -q`
- `pytest jsf/tests/test_default_fake.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae5978a71c832f95b8786f2a76bbad