### PR TITLE
Fix empty array generation

### DIFF
--- a/jsf/schema_types/array.py
+++ b/jsf/schema_types/array.py
@@ -22,6 +22,8 @@ class Array(BaseSchema):
         try:
             return super().generate(context)
         except ProviderNotSetException:
+            if self.items is None:
+                return []
             if isinstance(self.fixed, str):
                 self.minItems = self.maxItems = eval(self.fixed, context)()
             elif isinstance(self.fixed, int):
@@ -47,8 +49,11 @@ class Array(BaseSchema):
             return output
 
     def model(self, context: Dict[str, Any]) -> Tuple[Type, Any]:
-        _type = eval(
-            f"List[Union[{','.join([self.items.model(context)[0].__name__])}]]",
-            context["__internal__"],
-        )
+        if self.items is None:
+            _type = List[Any]
+        else:
+            _type = eval(
+                f"List[Union[{','.join([self.items.model(context)[0].__name__])}]]",
+                context["__internal__"],
+            )
         return self.to_pydantic(context, _type)

--- a/jsf/schema_types/object.py
+++ b/jsf/schema_types/object.py
@@ -19,14 +19,14 @@ SchemaDependency = Dict[str, "Object"]
 
 
 class Object(BaseSchema):
-    properties: Dict[str, BaseSchema] = {}
+    properties: List[BaseSchema] = []
     additionalProperties: Optional[Union[bool, BaseSchema]] = None
     required: Optional[List[str]] = None
     propertyNames: Optional[PropertyNames] = None
     minProperties: Optional[int] = None
     maxProperties: Optional[int] = None
     dependencies: Optional[Union[PropertyDependency, SchemaDependency]] = None
-    patternProperties: Optional[Dict[str, BaseSchema]] = None
+    patternProperties: Optional[List[BaseSchema]] = None
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "Object":

--- a/jsf/tests/test_default_fake.py
+++ b/jsf/tests/test_default_fake.py
@@ -548,11 +548,11 @@ def test_use_defaults_and_examples(TestData):
 def test_gen_empty_list(TestData):
     with open(TestData / "empty-list.json") as file:
         schema = json.load(file)
-    p = JSF(schema)
+    p = JSF(schema, allow_none_optionals=0.0)
 
     fake_data = [p.generate(use_defaults=True, use_examples=True) for _ in range(10)]
     for d in fake_data:
         assert isinstance(d, dict)
-        assert d in ["items"]
+        assert "items" in d
         assert isinstance(d["items"], list)
         assert len(d["items"]) == 0


### PR DESCRIPTION
## Summary
- allow arrays with no defined items to generate empty lists
- parse object properties as lists and ignore unused keys
- add regression test for empty list schemas

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae65479314832f8f6aa145a6559b54