### PR TITLE
Ensure arrays with item schemas are non-empty by default

### DIFF
--- a/jsf/schema_types/array.py
+++ b/jsf/schema_types/array.py
@@ -9,7 +9,12 @@ from jsf.schema_types.base import BaseSchema, ProviderNotSetException
 class Array(BaseSchema):
     items: Optional[BaseSchema] = None
     contains: Optional[BaseSchema] = None  # NOTE: Validation only
-    minItems: Optional[int] = 0
+    # If `items` is provided in the schema, JSON Schema treats the array as
+    # having an item type.  In that case JSF should emit at least one element
+    # by default.  Using ``None`` here allows us to distinguish between the
+    # schema omitting ``minItems`` and explicitly setting ``minItems`` to ``0``
+    # which callers may rely on.
+    minItems: Optional[int] = None
     maxItems: Optional[int] = 5
     uniqueItems: Optional[bool] = False
     fixed: Optional[Union[int, str]] = Field(None, alias="$fixed")
@@ -23,26 +28,41 @@ class Array(BaseSchema):
             return super().generate(context)
         except ProviderNotSetException:
             if self.items is None:
+                # No item schema means we cannot infer what the array should
+                # contain, therefore return an empty list.
                 return []
+
             if isinstance(self.fixed, str):
                 self.minItems = self.maxItems = eval(self.fixed, context)()
             elif isinstance(self.fixed, int):
                 self.minItems = self.maxItems = self.fixed
 
             depth = context["state"]["__depth__"]
+
+            # ``minItems`` may be ``None`` when it wasn't provided in the
+            # schema.  In that scenario we want non-empty arrays if an item
+            # schema exists.  When the user explicitly sets ``minItems`` to 0
+            # we honour that and allow empty arrays.
+            min_items = (
+                int(self.minItems)
+                if self.minItems is not None
+                else (0 if self.items is None else 1)
+            )
+            max_items = int(self.maxItems) if self.maxItems is not None else 5
+
             output = []
-            for _ in range(random.randint(int(self.minItems), int(self.maxItems))):
+            for _ in range(random.randint(min_items, max_items)):
                 output.append(self.items.generate(context))
                 context["state"]["__depth__"] = depth
             if self.uniqueItems and self.items.type == "object":
                 output = [dict(s) for s in {frozenset(d.items()) for d in output}]
-                while len(output) < self.minItems:
+                while len(output) < min_items:
                     output.append(self.items.generate(context))
                     output = [dict(s) for s in {frozenset(d.items()) for d in output}]
                     context["state"]["__depth__"] = depth
             elif self.uniqueItems:
                 output = set(output)
-                while len(output) < self.minItems:
+                while len(output) < min_items:
                     output.add(self.items.generate(context))
                     context["state"]["__depth__"] = depth
                 output = list(output)


### PR DESCRIPTION
## Summary
- adjust Array schema generation so lists with `items` default to at least one element
- prevent flaky empty arrays in nested list generation

## Testing
- `pytest jsf/tests/test_default_fake.py::test_gen_empty_list_pro -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae6e318f78832fb2fdeecf23f5af0a